### PR TITLE
chore: comment out Google sign-in until OAuth is configured

### DIFF
--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type FormEvent } from 'react'
 import { Link } from 'react-router-dom'
-import { signIn, signUp, signInWithGoogle, signInWithMagicLink } from '@/lib/auth'
+import { signIn, signUp, signInWithMagicLink } from '@/lib/auth'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -77,13 +77,14 @@ export default function LoginModal({ open, onOpenChange }: LoginModalProps) {
     }
   }
 
-  async function handleGoogleSignIn() {
-    setError(null)
-    const { error: oauthError } = await signInWithGoogle()
-    if (oauthError) {
-      setError(oauthError.message)
-    }
-  }
+  // TODO: Re-enable when Google OAuth is configured
+  // async function handleGoogleSignIn() {
+  //   setError(null)
+  //   const { error: oauthError } = await signInWithGoogle()
+  //   if (oauthError) {
+  //     setError(oauthError.message)
+  //   }
+  // }
 
   async function handleMagicLink(e: FormEvent) {
     e.preventDefault()
@@ -168,6 +169,7 @@ export default function LoginModal({ open, onOpenChange }: LoginModalProps) {
         </CardHeader>
 
         <CardContent className="space-y-4">
+          {/* TODO: Re-enable when Google OAuth is configured
           <Button
             variant="outline"
             className="w-full"
@@ -205,6 +207,7 @@ export default function LoginModal({ open, onOpenChange }: LoginModalProps) {
               </span>
             </div>
           </div>
+          */}
 
           {useMagicLink ? (
             <form onSubmit={handleMagicLink} className="space-y-4">

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useState, type FormEvent } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
-import { signIn, signUp, signInWithGoogle, signInWithMagicLink } from '@/lib/auth'
+import { signIn, signUp, signInWithMagicLink } from '@/lib/auth'
 import { useAuthStore } from '@/stores/authStore'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -61,13 +61,14 @@ export default function LoginPage() {
     }
   }
 
-  async function handleGoogleSignIn() {
-    setError(null)
-    const { error: oauthError } = await signInWithGoogle()
-    if (oauthError) {
-      setError(oauthError.message)
-    }
-  }
+  // TODO: Re-enable when Google OAuth is configured
+  // async function handleGoogleSignIn() {
+  //   setError(null)
+  //   const { error: oauthError } = await signInWithGoogle()
+  //   if (oauthError) {
+  //     setError(oauthError.message)
+  //   }
+  // }
 
   async function handleMagicLink(e: FormEvent) {
     e.preventDefault()
@@ -160,6 +161,7 @@ export default function LoginPage() {
         </CardHeader>
 
         <CardContent className="space-y-4">
+          {/* TODO: Re-enable when Google OAuth is configured
           <Button
             variant="outline"
             className="w-full"
@@ -197,6 +199,7 @@ export default function LoginPage() {
               </span>
             </div>
           </div>
+          */}
 
           {useMagicLink ? (
             <form onSubmit={handleMagicLink} className="space-y-4">


### PR DESCRIPTION
This pull request temporarily disables the Google OAuth sign-in option in both the `LoginModal` component and the `LoginPage` page. All related code for Google sign-in has been commented out, with clear TODOs indicating that it should be re-enabled once Google OAuth is properly configured. The rest of the authentication logic (email/password and magic link) remains unchanged.

Authentication logic updates:

* Commented out all imports, handler functions, and UI elements related to `signInWithGoogle` in both `src/components/LoginModal.tsx` and `src/pages/LoginPage.tsx`, with TODOs for future re-enablement when Google OAuth is configured. [[1]](diffhunk://#diff-f2231f61a2bd9e1690031f9984e068a6a371dde6b9760a8030cf74785b38628cL3-R3) [[2]](diffhunk://#diff-f2231f61a2bd9e1690031f9984e068a6a371dde6b9760a8030cf74785b38628cL80-R87) [[3]](diffhunk://#diff-f2231f61a2bd9e1690031f9984e068a6a371dde6b9760a8030cf74785b38628cR172) [[4]](diffhunk://#diff-f2231f61a2bd9e1690031f9984e068a6a371dde6b9760a8030cf74785b38628cR210) [[5]](diffhunk://#diff-5398e93fcf11b2ca16af33ab623e60bdcbf200391af9d6fe8f8cec9dc188b52cL3-R3) [[6]](diffhunk://#diff-5398e93fcf11b2ca16af33ab623e60bdcbf200391af9d6fe8f8cec9dc188b52cL64-R71) [[7]](diffhunk://#diff-5398e93fcf11b2ca16af33ab623e60bdcbf200391af9d6fe8f8cec9dc188b52cR164) [[8]](diffhunk://#diff-5398e93fcf11b2ca16af33ab623e60bdcbf200391af9d6fe8f8cec9dc188b52cR202)